### PR TITLE
stick: correctly print error when connect() fails

### DIFF
--- a/plugwise/stick.py
+++ b/plugwise/stick.py
@@ -127,7 +127,7 @@ class stick(object):
         except TimeoutException as e:
             self.logger.error("Timeout exception while initializing USBstick")
         except Exception as e:
-            self.logger.error("Unknown error : %s"), e
+            self.logger.error("Unknown error : %s", e)
 
     def connect(self, callback=None):
         """ Connect to stick and raise error if it fails"""


### PR DESCRIPTION
Testing out the example.py, I got the following error:

`Unknown error : %s`

The error printing line was malformed. Correcting the argument to the
%s now gives:

`Unknown error : module 'serial' has no attribute 'PARITY_NONE'`

Signed-off-by: Graham Whaley <graham.whaley@gmail.com>